### PR TITLE
fix export error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,4 @@ export interface wcsOptions {
   control?: number;
 }
 
-declare function wcswidth(str: string, opts?: wcsOptions): number;
-
-export = wcswidth;
+export default function wcswidth(str: string, opts?: wcsOptions): number;


### PR DESCRIPTION
TS fails to compile.

node_modules/@topcli/wcwidth/index.d.ts:8:1 - error TS2309: An export assignment cannot be used in a module with other exported elements.
